### PR TITLE
Update page title for walk view

### DIFF
--- a/projects/ngx-ramblers/src/app/pages/walks/walk-list/walk-list.component.ts
+++ b/projects/ngx-ramblers/src/app/pages/walks/walk-list/walk-list.component.ts
@@ -308,7 +308,7 @@ export class WalkListComponent implements OnInit, OnDestroy {
       this.logger.debug("walk-id from route params:", this.currentWalkId);
     }));
     this.display.refreshCachedData();
-    this.pageService.setTitle("Home");
+    this.pageService.setTitle("Walks");
     this.subscriptions.push(this.authService.authResponse().subscribe((loginResponse: LoginResponse) => this.refreshWalks(loginResponse)));
   }
 

--- a/projects/ngx-ramblers/src/app/pages/walks/walk-view/walk-view.ts
+++ b/projects/ngx-ramblers/src/app/pages/walks/walk-view/walk-view.ts
@@ -35,6 +35,7 @@ import { NgClass } from "@angular/common";
 import { WalkDetailsComponent } from "./walk-details";
 import { DisplayDayPipe } from "../../../pipes/display-day.pipe";
 import { VenueIconPipe } from "../../../pipes/venue-icon.pipe";
+import { PageService } from "../../../services/page.service";
 
 @Component({
     selector: "app-walk-view",
@@ -307,6 +308,7 @@ export class WalkViewComponent implements OnInit, OnDestroy {
   private dateUtils = inject(DateUtilsService);
   public meetupService = inject(MeetupService);
   private urlService = inject(UrlService);
+  private pageService = inject(PageService);
   protected stringUtils = inject(StringUtilsService);
   private systemConfigService = inject(SystemConfigService);
   private notifierService = inject(NotifierService);
@@ -345,6 +347,7 @@ export class WalkViewComponent implements OnInit, OnDestroy {
       this.logger.info("event received:", config);
       this.updateGoogleMapIfApplicable();
     });
+    this.pageService.setTitle(this.displayedWalk.walk.displayName);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Hi Nick,

When on a walk page, the page title is 'Stag Walkers - Home'

<img width="446" alt="image" src="https://github.com/user-attachments/assets/6af6e7a7-b8ff-48bb-beb4-125807964229" />

When on the ramblers website, the page title is the walk display name.

<img width="553" alt="image" src="https://github.com/user-attachments/assets/092143f8-e15b-4eaf-97dd-390962ddc640" />

What do you think about updating the title for the walks view? (this code has not been tested)

I also pushed a change for the walks list, so that it would display as "{group name} - Walks".
