### PR TITLE
Set contact subject by optional query parameter

### DIFF
--- a/projects/ngx-ramblers/src/app/pages/contact-us/contact-us-modal.component.ts
+++ b/projects/ngx-ramblers/src/app/pages/contact-us/contact-us-modal.component.ts
@@ -243,7 +243,7 @@ export class ContactUsModalComponent implements OnInit, OnDestroy, AfterViewInit
         });
       }
 
-      this.contactFormDetails.subject = "Website Enquiry";
+      this.contactFormDetails.subject = this.queryParams["subject"] || "Website Enquiry";
       this.logger.info("ngOnInit - queryParams:", this.queryParams, "bsModalRef:", this.bsModalRef, "committeeMember:", this.committeeMember);
     }));
   }


### PR DESCRIPTION
Hi Nick,

We were thinking of using the contact form for various purposes, such as contacting the committee about leading walks. So, I was thinking it could be useful to inject an email subject using the URL. For example; `stagwalkers.org.uk/?contact-us&role=walks-co-ordinator&redirect=contact-us&subject=Website%20Enquiry%3A%20Volunteering%20as%20a%20Walk%20Leader`.

Then we could provide a link that fills in the subject depending on the context. What do you think?